### PR TITLE
introuducing docking mode

### DIFF
--- a/handshake_client.go
+++ b/handshake_client.go
@@ -1197,7 +1197,7 @@ func (c *Conn) verifyServerCertificate(certificates [][]byte) error {
 				return &CertificateVerificationError{UnverifiedCertificates: certs, Err: err}
 			}
 		}
-	} else if !c.config.InsecureSkipVerify && !c.authed.Load() {
+	} else if !c.config.InsecureSkipVerify && !c.pauthed.Load() {
 		// Only verify the certificate if the connection is not authenticated by protean protocol.
 		// [UTLS SECTION START]
 		opts := x509.VerifyOptions{

--- a/protean.go
+++ b/protean.go
@@ -7,6 +7,7 @@ package tls
 import (
 	"bytes"
 	"context"
+	"crypto/cipher"
 	"crypto/ecdh"
 	"crypto/ed25519"
 	"crypto/sha256"
@@ -121,10 +122,11 @@ type PConn struct {
 	upstreamBuf *bytes.Buffer
 
 	cfg *PConfig
+	wg  sync.WaitGroup
 }
 
 func (p *PConn) Authed() bool {
-	return p.authed.Load()
+	return p.pauthed.Load()
 }
 
 type PConfig struct {
@@ -139,6 +141,8 @@ type PConfig struct {
 	// Common Config
 	ServerFp Fingerprint
 	ClientFp Fingerprint
+
+	DockingModeEnabled bool
 
 	once sync.Once
 
@@ -383,6 +387,97 @@ func (p *PConn) Read(b []byte) (int, error) {
 	return p.Conn.Read(b)
 }
 
+type pstream struct {
+	*Conn
+}
+
+func (p *pstream) Read(b []byte) (int, error) {
+	if err := p.Handshake(); err != nil {
+		return 0, err
+	}
+
+	if len(b) == 0 {
+		return 0, nil
+	}
+
+	p.pcond.L.Lock()
+	defer p.pcond.L.Unlock()
+
+	for p.pinput.Len() == 0 {
+		if p.eof {
+			return 0, io.EOF
+		}
+		p.pcond.Wait()
+	}
+
+	return p.pinput.Read(b)
+}
+
+func (p *pstream) Write(b []byte) (int, error) {
+	// interlock with Close below
+	for {
+		x := p.activeCall.Load()
+		if x&1 != 0 {
+			return 0, net.ErrClosed
+		}
+		if p.activeCall.CompareAndSwap(x, x+2) {
+			break
+		}
+	}
+	defer p.activeCall.Add(-2)
+
+	if err := p.Handshake(); err != nil {
+		return 0, err
+	}
+
+	p.out.Lock()
+	defer p.out.Unlock()
+
+	if err := p.out.err; err != nil {
+		return 0, err
+	}
+
+	if !p.isHandshakeComplete.Load() {
+		return 0, alertInternalError
+	}
+
+	if p.closeNotifySent {
+		return 0, errShutdown
+	}
+
+	// TLS 1.0 is susceptible to a chosen-plaintext
+	// attack when using block mode ciphers due to predictable IVs.
+	// This can be prevented by splitting each Application Data
+	// record into two records, effectively randomizing the IV.
+	//
+	// https://www.openssl.org/~bodo/tls-cbc.txt
+	// https://bugzilla.mozilla.org/show_bug.cgi?id=665814
+	// https://www.imperialviolet.org/2012/01/15/beastfollowup.html
+
+	var m int
+	if len(b) > 1 && p.vers == VersionTLS10 {
+		if _, ok := p.out.cipher.(cipher.BlockMode); ok {
+			n, err := p.writeRecordLocked(recordTypeApplicationData, b[:1])
+			if err != nil {
+				return n, p.out.setErrorLocked(err)
+			}
+			m, b = 1, b[1:]
+		}
+	}
+
+	n, err := p.writeRecordLocked(recordTypeApplicationData, b, withPayloadDataPrefix(proteanDataPrefix))
+	return n + m, p.out.setErrorLocked(err)
+}
+
+func (p *PConn) PStream() (net.Conn, error) {
+	if !p.cfg.DockingModeEnabled {
+		return nil, errors.New("protean: docking mode is not enabled")
+	}
+	return &pstream{
+		Conn: p.Conn,
+	}, nil
+}
+
 func (p *PConn) Write(b []byte) (int, error) {
 	bc, ok := p.upstream.(*bufConn)
 	// In relay mode, the upstream is a bufConn
@@ -405,6 +500,9 @@ func (p *PConn) CloseWrite() error {
 }
 
 func (p *PConn) serverHandshake(ctx context.Context) error {
+	p.ponce.Do(func() {
+		p.pcond = sync.NewCond(&sync.Mutex{})
+	})
 	err := p.tryServerHandshake(ctx)
 	if err != nil {
 		if errors.Is(err, ErrAbortHandshake) {
@@ -414,7 +512,15 @@ func (p *PConn) serverHandshake(ctx context.Context) error {
 		p.upstream = &bufConn{p.upstream, p.upstreamBuf}
 		p.isHandshakeComplete.Store(true)
 	} else {
-		p.authed.Store(true)
+		p.pauthed.Store(true)
+	}
+
+	if p.cfg.DockingModeEnabled {
+		// Recover the delegate connection
+		if dc, ok := p.delegateConn.conn.(*delegateConn); ok {
+			p.delegateConn.conn = dc.Conn
+		}
+		p.docking()
 	}
 
 	return nil


### PR DESCRIPTION
The introduction of the docking mode is intended to provide a mechanism for traffic obfuscation. It allows an upper-layer traffic obfuscator to insert camouflage traffic while transmitting honest traffic. The goal is to mitigate detection issues such as TLS-in-TLS and HTTP server fingerprinting. In the spec, we have made a preliminary exploration of this mechanism: https://github.com/ban6cat6/protean/blob/master/docs/protocol.md#post-handshake-messages. At the same time, there is now another protocol called TLSMirror that has adopted a similar approach to achieve traffic obfuscation: https://github.com/net4people/bbs/issues/496.

In docking mode, the Protean server creates two record-level streams for each TLS connection:
1. The first stream forwards traffic to the target server.
2. The second stream is used to smuggle custom traffic between the client and the server.

The records of these two streams are independent of each other. Isolation between them is achieved via a special application data prefix (called the Protean data prefix), which is 16 bytes long.

According to the birthday paradox, the probability of a randomly generated data block of 16 bytes or more colliding with the Protean data prefix is 1/2⁶⁴. Even if we exhaust the maximum number of records that can be transmitted in a single connection, the expected number of collisions is still just 1/2⁶⁴. This length is already sufficiently secure.
