### PR TITLE
tls: fail fast on unsupported upstream cipher suite

### DIFF
--- a/common.go
+++ b/common.go
@@ -917,8 +917,8 @@ type Config struct {
 	autoSessionTicketKeys []ticketKey
 
 	// [PROTEAN SECTION BEGINS]
-	generateClientKeyExchange func(curve ecdh.Curve) (*ecdh.PrivateKey, error)
-	establishHandshakeKeys func(hs *clientHandshakeStateTLS13) ([]byte, error)
+	generateClientKeyExchange  func(curve ecdh.Curve) (*ecdh.PrivateKey, error)
+	establishHandshakeKeys     func(hs *clientHandshakeStateTLS13) ([]byte, error)
 	RandomExplicitNonceEnabled bool
 	// [PROTEAN SECTION ENDS]
 }
@@ -1027,7 +1027,7 @@ func (c *Config) Clone() *Config {
 		autoSessionTicketKeys:               c.autoSessionTicketKeys,
 
 		PreferSkipResumptionOnNilExtension: c.PreferSkipResumptionOnNilExtension, // [UTLS]
-		RandomExplicitNonceEnabled:         c.RandomExplicitNonceEnabled, // [PROTEAN]
+		RandomExplicitNonceEnabled:         c.RandomExplicitNonceEnabled,         // [PROTEAN]
 	}
 }
 

--- a/protean_client.go
+++ b/protean_client.go
@@ -134,7 +134,7 @@ func (p *PConn) clientHandshake(ctx context.Context) (err error) {
 			return nil, errServerNotAuthed
 		}
 
-		sharedKey := psecret.HandshakeSecret(salt, 64)
+		sharedKey := psecret.HandshakeSecret(salt, pKeyLen)
 		p.pauthed.Store(true)
 		return sharedKey, nil
 	}

--- a/protean_key_schedule.go
+++ b/protean_key_schedule.go
@@ -18,6 +18,9 @@ const (
 	pTicketFinishedLabel  = "protean session ticket finished"
 	pHandshakeSecretLabel = "protean handshake secret"
 	pTrafficSecretLabel   = "protean traffic secret"
+
+	// protean requires a 64-byte key for the traffic secret
+	pKeyLen = 64
 )
 
 func mkPKeyShareLabel(curveID CurveID) string {


### PR DESCRIPTION
Optimize ServerHello handling by immediately returning an error when the negotiated cipher suite is not supported, instead of compute the handshake secret first. This reduces unnecessary processing and simplifies the error path.